### PR TITLE
Removed relative imports and plotting update

### DIFF
--- a/fruitbat/__init__.py
+++ b/fruitbat/__init__.py
@@ -2,7 +2,8 @@ from . import estimate
 from . import utils
 from . import cosmology
 from . import plot
-from .frb import Frb
+from ._frb import Frb
+import numpy as np
 
 __name__ = "fruitbat"
 __author__ = "Adam Batten (@abatten)"

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -11,9 +11,8 @@ import astropy.units as u
 
 import pyymw16 as ymw16
 
-from . import estimate
-from . import cosmology
-from ._fruitbatstrings import dm_units_doc
+from fruitbat import estimate, cosmology
+from fruitbat._fruitbatstrings import dm_units_doc
 
 __all__ = ["Frb"]
 
@@ -149,9 +148,6 @@ class Frb(object):
                  width=None, peak_flux=None, fluence=None, obs_bandwidth=None,
                  utc=None):
 
-        # TO DO:
-        # There are a few other parameters that I should add:
-        # dm_index
 
         self.name = name
 
@@ -287,7 +283,7 @@ class Frb(object):
 
         Returns
         -------
-        :ob:`astropy.units.Quantity`
+        :obj:`astropy.units.Quantity`
             The dispersion measure excess.
 
         Notes
@@ -399,7 +395,6 @@ class Frb(object):
         .. math::
 
             \\rm{F_{obs} = W_{obs} S_{peak, obs}}
-
         """
 
 
@@ -461,6 +456,8 @@ class Frb(object):
         cosmo = cosmology.builtin()[self.cosmology_method]
         return cosmo.comoving_distance(z_sample)
 
+#    Currently peak luminosity is removed since it's unclear from literature 
+#    how to accuratly calculate this quantity
 #    def calc_peak_luminosity(self):
 #        """
 #        Returns

--- a/fruitbat/cosmology.py
+++ b/fruitbat/cosmology.py
@@ -3,10 +3,7 @@ Module for defining different cosmologies
 """
 from astropy import units as u
 import astropy.cosmology
-from astropy.cosmology.core import FlatLambdaCDM
-from astropy.cosmology.core import FlatwCDM
-from astropy.cosmology.core import LambdaCDM
-from astropy.cosmology.core import wCDM
+from astropy.cosmology.core import (FlatLambdaCDM, FlatwCDM, LambdaCDM, wCDM)
 from e13tools import docstring_copy
 
 __all__ = ["WMAP5", "WMAP7", "WMAP9", "Planck13", "Planck15", "Planck18",

--- a/fruitbat/estimate.py
+++ b/fruitbat/estimate.py
@@ -1,8 +1,8 @@
 from e13tools import docstring_substitute
 
-from . import utils
-from ._fruitbatstrings import dm_units_doc
-from .cosmology import keys as cosmo_keys, builtin
+from fruitbat import utils
+from fruitbat._fruitbatstrings import dm_units_doc
+from fruitbat.cosmology import keys as cosmo_keys, builtin
 
 __all__ = ["redshift", "methods"]
 
@@ -11,7 +11,7 @@ def methods(string=False):
     """
     Defines the list of avaliable method keywords.
 
-    Methods currently avaliable: ioka2003, inoue2004, zhang2018
+    Methods currently avaliable: Ioka2003, Inoue2004, Zhang2018
 
     Parameters
     ----------


### PR DESCRIPTION
* Changes frb.py to _frb.py to remove the frb namespace. This will
prevent users from accidently trying to use frb instead of Frb when
defining the Frb object.
* Removed relative imports from not __init__ files and made explicit
imports from fruitbat.
* Changed the plot functions to have passed_ax and returns the figures
instead of autosaving the file. Now only saves when given a filename.