### PR TITLE
Update to version 0.2.0 (Python 2.7 compatibility)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: xenial
 sudo: false
 
 python:
+    - "2.7"
     - "3.5"
     - "3.6"
     - "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ python:
     - "3.7"
 
 install:
-    - pip install pytest-cov
-    - pip install codecov
-    - pip install -r requirements.txt
+    - pip install --upgrade pip setuptools
+    - pip install -r requirements_dev.txt
 
 script:
     - pytest

--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,8 @@ each requirement.
 
  - matplotlib: Modules for plotting
 
+ - six: Checking compatability between python 2 and python 3
+
  - pyymw16: Python wrapper for YMW16 galactic dispersion measure model.
 
  - e13tools: Utility tools for writing docstrings.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'Adam Batten'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.1.1'
+release = '0.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/user_guide/getting_started.rst
+++ b/docs/source/user_guide/getting_started.rst
@@ -21,14 +21,22 @@ the repository:
 
 Requirements
 ************
-* numpy >= 1.12.0
-* astropy >= 2.0.0
-* scipy >= 1.0.0
-* pyymw16 >= 2.0.4
-* e13Tools >= 0.5.3
+Below are the listed requirements for running ``fruitbat`` and the purpose for
+each requirement.
 
+ - numpy: Array manipulation
 
-Pyymw16_ is a python wrapper for the YMW16 galactic dispersion measure model.
+ - scipy: Modules for integration and interpolation
+
+ - astropy: Modules for cosmology, coordinates, constants and units
+
+ - matplotlib: Modules for plotting
+
+ - six: Checking compatability between python 2 and python 3
+
+ - pyymw16: Python wrapper for YMW16 galactic dispersion measure model.
+
+ - e13tools: Utility tools for writing docstrings.
 
 
 Using Fruitbat

--- a/fruitbat/__init__.py
+++ b/fruitbat/__init__.py
@@ -9,5 +9,5 @@ import numpy as np
 
 __name__ = "fruitbat"
 __author__ = "Adam Batten (@abatten)"
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 __all__ = ['Frb', 'estimate', 'utils', 'cosmology', 'plot']

--- a/fruitbat/__init__.py
+++ b/fruitbat/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, print_function, division
+
 from . import estimate
 from . import utils
 from . import cosmology

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -17,7 +17,7 @@ from fruitbat import estimate, cosmology
 
 __all__ = ["Frb"]
 
-class Frb:
+class Frb(object):
     """
     Create a :class:`~Frb` object using the observered properties of a FRB
     including dispersion measure (DM) and its sky coordinates. This class

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -145,11 +145,11 @@ class Frb(object):
 
     """
 
-    def __init__(self, dm, *args, name=None, raj=None, decj=None, gl=None, 
-                 gb=None, dm_galaxy=0.0, dm_excess=None, z_host=None, 
-                 dm_host_est=0.0, dm_host_loc=0.0, dm_index=None, 
-                 scatt_index=None, snr=None, width=None, peak_flux=None, 
-                 fluence=None, obs_bandwidth=None, utc=None):
+    def __init__(self, dm, name=None, raj=None, decj=None, gl=None, gb=None, 
+                 dm_galaxy=0.0, dm_excess=None, z_host=None, dm_host_est=0.0, 
+                 dm_host_loc=0.0, dm_index=None, scatt_index=None, snr=None,
+                 width=None, peak_flux=None, fluence=None, obs_bandwidth=None,
+                 utc=None, *args, **kwargs):
 
         self.name = name
         self.dm = dm

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -14,12 +14,9 @@ import astropy.units as u
 import pyymw16 as ymw16
 
 from fruitbat import estimate, cosmology
-from fruitbat._fruitbatstrings import dm_units_doc
 
 __all__ = ["Frb"]
 
-
-@docstring_substitute(dm_units=dm_units_doc)
 class Frb:
     """
     Create a :class:`~Frb` object using the observered properties of a FRB
@@ -45,7 +42,7 @@ class Frb:
     dm : float
         The observed dispersion measure of the FRB. This is without Milky Way
         or host galaxy subtraction.
-        Units: %(dm_units)s
+        Units: pc cm**-3
 
     Keyword Arguments
     -----------------
@@ -73,13 +70,13 @@ class Frb:
     dm_galaxy : float, optional
         The modelled contribution to the FRB DM by electrons in the Milky Way.
         This value is calculated using :meth:`calc_dm_galaxy`
-        Units: %(dm_units)s Default: 0.0
+        Units: pc cm**-3 Default: 0.0
 
     dm_excess : float or None, optional
         The DM excess of the FRB over the estimated Galactic DM. If
         :attr:`dm_excess` is *None*, then :attr:`dm_excess` is calculated
         automatically with :meth:`calc_dm_excess`.
-        Units: %(dm_units)s Default: *None*
+        Units: pc cm**-3 Default: *None*
 
     z_host : float or None, optional
         The observed redshift of the localised FRB host galaxy.
@@ -91,14 +88,14 @@ class Frb:
         contributes to the observed DM, *not* the DM of the host galaxy.
         Setting this to a non-zero value and setting ``subtract_host=True``
         when calling :meth:`calc_redshift` accounts for the DM contribution
-        due to the host galaxy. Units: %(dm_units)s Default: 0.0
+        due to the host galaxy. Units: pc cm**-3 Default: 0.0
 
     dm_host_loc : float, optional
         The dispersion measure of a localised FRB host galaxy. This value is
         *not* the contribution to the observed DM, but the DM at the host
         galaxy. The observed DM is :attr:`dm_host_loc` but attenuated by a
         factor of (1 + z). To use this, the redshift of the host galaxy must
-        be known. Units: %(dm_units)s Default: 0.0
+        be known. Units: pc cm**-3 Default: 0.0
 
     dm_index : float or None, optional
         The dispersion measure index of the burst :math:`\\alpha` such that
@@ -116,20 +113,20 @@ class Frb:
 
     width : float or None, optional
         The observed width of the pulse obtained by a pulse fitting algorithm.
-        Units: :math:`\\rm{ms}` Default: *None*
+        Units: ms Default: *None*
 
     peak_flux : float or None, optional
         The observed peak flux density of the burst.
-        Units: :math:`\\rm{Jy}` Default: *None*
+        Units: Jy Default: *None*
 
     fluence : float or None, optional
         The observed fluence of the FRB. If :attr:`fluence` is *None* and both
         :attr:`width` and :attr:`peak_flux` are not *None* then :attr:`fluence`
         is automatically calculated with :meth:`calc_fluence`
-        Units: :math:`\\rm{Jy\\ ms}` Default: *None*
+        Units: Jy ms Default: *None*
 
     obs_bandwidth : float or None, optional
-        The observing bandwidth in MHz. Default: *None*
+        The observing bandwidth. Units: MHz Default: *None*
 
     utc : str or None, optional
         The UTC time of the FRB Burst. Format should be of the form

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -1,6 +1,8 @@
 """
 Frb class and method functions.
 """
+from __future__ import print_function, absolute_import, division
+
 from e13tools import docstring_substitute
 
 import numpy as np
@@ -140,17 +142,16 @@ class Frb(object):
     >>> FRB = fruitbat.Frb(879, gl="12:31:40.5", gb="3:41:10.0")
     >>> FRB.calc_dm_galaxy()
     >>> FRB.calc_redshift()
+
     """
 
-    def __init__(self, dm, *, name=None, raj=None, decj=None, gl=None, gb=None,
-                 dm_galaxy=0.0, dm_excess=None, z_host=None, dm_host_est=0.0,
-                 dm_host_loc=0.0, dm_index=None, scatt_index=None, snr=None,
-                 width=None, peak_flux=None, fluence=None, obs_bandwidth=None,
-                 utc=None):
-
+    def __init__(self, dm, *args, name=None, raj=None, decj=None, gl=None, 
+                 gb=None, dm_galaxy=0.0, dm_excess=None, z_host=None, 
+                 dm_host_est=0.0, dm_host_loc=0.0, dm_index=None, 
+                 scatt_index=None, snr=None, width=None, peak_flux=None, 
+                 fluence=None, obs_bandwidth=None, utc=None):
 
         self.name = name
-
         self.dm = dm
         self.dm_galaxy = dm_galaxy
         self.dm_host_est = dm_host_est

--- a/fruitbat/_frb.py
+++ b/fruitbat/_frb.py
@@ -20,7 +20,7 @@ __all__ = ["Frb"]
 
 
 @docstring_substitute(dm_units=dm_units_doc)
-class Frb(object):
+class Frb:
     """
     Create a :class:`~Frb` object using the observered properties of a FRB
     including dispersion measure (DM) and its sky coordinates. This class

--- a/fruitbat/_fruitbatstrings.py
+++ b/fruitbat/_fruitbatstrings.py
@@ -1,6 +1,0 @@
-"""
-Contains a collection of strings that appear many times in the fruitbat
-documentation.
-"""
-
-dm_units_doc = ":math:`\\rm{pc\\ cm^{-3}}`"

--- a/fruitbat/cosmology.py
+++ b/fruitbat/cosmology.py
@@ -1,6 +1,8 @@
 """
 Module for defining different cosmologies
 """
+from __future__ import print_function, absolute_import, division
+
 from astropy import units as u
 import astropy.cosmology
 from astropy.cosmology.core import (FlatLambdaCDM, FlatwCDM, LambdaCDM, wCDM)

--- a/fruitbat/estimate.py
+++ b/fruitbat/estimate.py
@@ -116,4 +116,3 @@ def _get_redshift_from_table(dm, method, cosmology):
     return z
 
 
-

--- a/fruitbat/estimate.py
+++ b/fruitbat/estimate.py
@@ -3,7 +3,6 @@ from __future__ import print_function, absolute_import, division
 from e13tools import docstring_substitute
 
 from fruitbat import utils
-from fruitbat._fruitbatstrings import dm_units_doc
 from fruitbat.cosmology import keys as cosmo_keys, builtin
 
 __all__ = ["redshift", "methods"]
@@ -34,8 +33,7 @@ def methods(string=False):
     return methods
 
 
-@docstring_substitute(dmunits=dm_units_doc, methods=methods(string=True), 
-                      cosmo=cosmo_keys())
+@docstring_substitute(methods=methods(string=True), cosmo=cosmo_keys())
 def redshift(dm, dm_uncert=0.0, method='Inoue2004', cosmology='Planck18'):
     """
     Returns the redshift of a given dispersion measure using a
@@ -44,10 +42,10 @@ def redshift(dm, dm_uncert=0.0, method='Inoue2004', cosmology='Planck18'):
     Parameters
     ----------
     dm : float
-        Dispersion Measure. Units: %(dmunits)s
+        Dispersion Measure. Units: pc cm**-3
 
     dm_uncert : float or None
-        The uncertainty in the dispersion measure. Units: %(dmunits)s
+        The uncertainty in the dispersion measure. Units: pc cm**-3
 
     method : string, optional
         The DM-z relation to use to calculate the redshift.

--- a/fruitbat/estimate.py
+++ b/fruitbat/estimate.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import, division
+
 from e13tools import docstring_substitute
 
 from fruitbat import utils

--- a/fruitbat/plot.py
+++ b/fruitbat/plot.py
@@ -2,10 +2,6 @@ from __future__ import print_function, absolute_import, division
 
 from six import PY2
 
-if PY2:
-    import matplotlib
-    matplotlib.use('Agg')
-
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/fruitbat/plot.py
+++ b/fruitbat/plot.py
@@ -1,4 +1,11 @@
 from __future__ import print_function, absolute_import, division
+
+from six import PY2
+
+if PY2:
+    import matplotlib
+    matplotlib.use('Agg')
+
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/fruitbat/plot.py
+++ b/fruitbat/plot.py
@@ -104,15 +104,21 @@ def create_cosmology_comparison(filename="", extension="png", usetex=False,
         fig = plt.figure(figsize=(8, 8), constrained_layout=True)
         ax = fig.add_subplot(111)
 
-    # Add inset plot showing the part where cosmologies diverge the most.
-    axin = ax.inset_axes([0.05, 0.52, 0.45, 0.45])
-
     # Remove EAGLE from cosmologies since it is the same as Planck13
     cosmologies = cosmology.builtin()
     cosmologies.pop("EAGLE")
     cosmologies = cosmologies.keys()
 
     dm_vals = np.linspace(0, 3000, 1000)
+
+    add_axin = True
+    try:
+        # Add inset plot showing the part where cosmologies diverge the most.
+        axin = ax.inset_axes([0.05, 0.52, 0.45, 0.45])
+    except Exception:
+        print("""Skipping inset axis in cosmology plot. Requires Python 3 and 
+              Matplotlib 3.0""")
+        add_axin = False
 
     colours = ['#a6cee3', '#1f78b4', '#b2df8a',
                '#33a02c', '#fb9a99', '#e31a1c']
@@ -124,18 +130,21 @@ def create_cosmology_comparison(filename="", extension="png", usetex=False,
         for i, dm in enumerate(dm_vals):
             z_vals[i] = estimate.redshift(dm, cosmology=cosmo)
         ax.plot(dm_vals, z_vals, colours[j], label=label[j], **kwargs)
-        axin.plot(dm_vals, z_vals, colours[j], **kwargs)
+        if add_axin:
+            axin.plot(dm_vals, z_vals, colours[j], **kwargs)
 
     ax.set_xlabel(r"$\rm{DM\ \left[pc \ cm^{-3}\right]}$")
     ax.set_ylabel(r"$\rm{Redshift}$")
     plt.legend(loc='lower right', frameon=False)
 
-    axin.set_xlim(2800, 3000)
-    axin.set_ylim(3.0, 3.25)
-    axin.xaxis.set_tick_params(labelsize=8)
-    axin.yaxis.set_tick_params(labelsize=8)
+    if add_axin:
+        axin.set_xlim(2800, 3000)
+        axin.set_ylim(3.0, 3.25)
+        axin.xaxis.set_tick_params(labelsize=8)
+        axin.yaxis.set_tick_params(labelsize=8)
 
-    ax.indicate_inset_zoom(axin)
+        ax.indicate_inset_zoom(axin)
+
 
     if filename is not "":
         plt.savefig(".".join([filename, extension]))

--- a/fruitbat/plot.py
+++ b/fruitbat/plot.py
@@ -1,3 +1,4 @@
+from __future__ import print_function, absolute_import, division
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/fruitbat/tests/test_fruitbat.py
+++ b/fruitbat/tests/test_fruitbat.py
@@ -14,6 +14,7 @@ from fruitbat import utils
 from fruitbat import cosmology
 from fruitbat import estimate
 
+from six import PY2, PY3
 
 class TestFrbClass:
 
@@ -215,38 +216,44 @@ def test_check_keys_in_dict_all():
 class TestCreateTables:
 
     def test_create_tables_normal(self):
-        method_list = estimate.methods()
-        cosmology_list = fruitbat.cosmology.builtin()
+        if PY3:  # Only peform tests in Python 3
+            method_list = estimate.methods()
+            cosmology_list = fruitbat.cosmology.builtin()
 
-        # Create a lookup table for each method and cosmology
-        for method in method_list:
-            for key in cosmology_list:
-                cosmo = fruitbat.cosmology.builtin()[key]
-                outfile_name = "_".join(["pytest_output", method, key])
-                utils.create_lookup_table(outfile_name, method=method,
-                                          cosmo=cosmo, zmin=0, zmax=20,
-                                          num_samples=10000)
+            # Create a lookup table for each method and cosmology
+            for method in method_list:
+                for key in cosmology_list:
+                    cosmo = fruitbat.cosmology.builtin()[key]
+                    outfile_name = "_".join(["pytest_output", method, key])
+                    utils.create_lookup_table(outfile_name, method=method,
+                                              cosmo=cosmo, zmin=0, zmax=20,
+                                              num_samples=10000)
 
-                # Compare new tables to existing tables for 4 dm values
-                pre_calc_fn = ".".join(["_".join([method, key]), "npy"])
-                new_calc_fn = ".".join([outfile_name, "npy"])
-                cwd = os.getcwd()
+                    # Compare new tables to existing tables for 4 dm values
+                    pre_calc_fn = ".".join(["_".join([method, key]), "npy"])
+                    new_calc_fn = ".".join([outfile_name, "npy"])
+                    cwd = os.getcwd()
 
-                pre_calc = utils.load_lookup_table(pre_calc_fn)
-                new_calc = utils.load_lookup_table(new_calc_fn, cwd)
+                    pre_calc = utils.load_lookup_table(pre_calc_fn)
+                    new_calc = utils.load_lookup_table(new_calc_fn, cwd)
 
-                test_dm_list = [0, 100, 1000, 2000]
+                    test_dm_list = [0, 100, 1000, 2000]
 
-                for dm in test_dm_list:
-                    assert pre_calc(dm)[()] == new_calc(dm)[()]
+                    for dm in test_dm_list:
+                        assert pre_calc(dm)[()] == new_calc(dm)[()]
+        elif PY2:
+            pass
 
     def test_create_table_zhang_figm_free_elec(self):
-        cosmo = fruitbat.cosmology.builtin()["Planck18"]
-        outfile_name = "_".join(["pytest_output", "Zhang2018", 
-                                 "Planck18", "figm_free_elec"])
+        if PY3:  # Only perform tests in Python 3
+            cosmo = fruitbat.cosmology.builtin()["Planck18"]
+            outfile_name = "_".join(["pytest_output", "Zhang2018", 
+                                     "Planck18", "figm_free_elec"])
 
-        utils.create_lookup_table(outfile_name, method="Zhang2018", 
-                                  cosmo=cosmo, f_igm=0.5, free_elec=0.4)
+            utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                      cosmo=cosmo, f_igm=0.5, free_elec=0.4)
+        elif PY2:
+            pass
 
     def test_create_table_zhang_figm_error(self):
         cosmo = fruitbat.cosmology.builtin()["Planck18"]

--- a/fruitbat/tests/test_fruitbat.py
+++ b/fruitbat/tests/test_fruitbat.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 from glob import glob
 import pytest
+import pytest_mpl
 
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -293,14 +294,16 @@ class TestCreateTables:
 class TestPlots:
     # Test that the method plot creates an output file
     def test_method_plot(self):
-        fruitbat.plot.create_method_comparison(filename="pytest_output_method")
+        with pytest_mpl.plugin.switch_backend('Agg'):
+            fruitbat.plot.create_method_comparison(filename="pytest_output_method")
         cwd = os.getcwd()
         if not os.path.exists(os.path.join(cwd, "pytest_output_method.png")):
             raise OSError
 
     # Test that the cosmology plot creates and output file
     def test_cosmology_plot(self):
-        fruitbat.plot.create_cosmology_comparison(filename="pytest_output_cosmo")
+        with pytest_mpl.plugin.switch_backend('Agg'):
+            fruitbat.plot.create_cosmology_comparison(filename="pytest_output_cosmo")
         cwd = os.getcwd()
         if not os.path.exists(os.path.join(cwd, "pytest_output_cosmo.png")):
             raise OSError

--- a/fruitbat/tests/test_fruitbat.py
+++ b/fruitbat/tests/test_fruitbat.py
@@ -242,36 +242,52 @@ class TestCreateTables:
                     for dm in test_dm_list:
                         assert pre_calc(dm)[()] == new_calc(dm)[()]
         elif PY2:
-            pass
+            with pytest.raises(SystemError):
+                utils.create_lookup_table("pytest_output", "Zhang2018", 
+                                          "Planck18")
 
     def test_create_table_zhang_figm_free_elec(self):
+        cosmo = fruitbat.cosmology.builtin()["Planck18"]
+        outfile_name = "_".join(["pytest_output", "Zhang2018", 
+                                 "Planck18", "figm_free_elec"])
         if PY3:  # Only perform tests in Python 3
-            cosmo = fruitbat.cosmology.builtin()["Planck18"]
-            outfile_name = "_".join(["pytest_output", "Zhang2018", 
-                                     "Planck18", "figm_free_elec"])
-
             utils.create_lookup_table(outfile_name, method="Zhang2018", 
                                       cosmo=cosmo, f_igm=0.5, free_elec=0.4)
         elif PY2:
-            pass
+            with pytest.raises(SystemError):
+                utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                          cosmo=cosmo, f_igm=0.5, 
+                                          free_elec=0.4)
 
     def test_create_table_zhang_figm_error(self):
         cosmo = fruitbat.cosmology.builtin()["Planck18"]
         outfile_name = "_".join(["pytest_output", "Zhang2018", 
                                  "Planck18", "figm_error"])
 
-        with pytest.raises(ValueError):
-            utils.create_lookup_table(outfile_name, method="Zhang2018", 
-                                      cosmo=cosmo, f_igm=-1)
+        if PY3:
+            with pytest.raises(ValueError):
+                utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                          cosmo=cosmo, f_igm=-1)
+        elif PY2:
+            with pytest.raises(SystemError):
+                utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                          cosmo=cosmo, f_igm=-1)
+
             
     def test_create_table_zhang_free_elec_error(self):
         cosmo = fruitbat.cosmology.builtin()["Planck18"]
         outfile_name = "_".join(["pytest_output", "Zhang2018", 
                                  "Planck18", "free_elec_error"])
 
-        with pytest.raises(ValueError):
-            utils.create_lookup_table(outfile_name, method="Zhang2018", 
-                                      cosmo=cosmo, free_elec=-1)
+        if PY3:
+            with pytest.raises(ValueError):
+                utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                          cosmo=cosmo, free_elec=-1)
+        elif PY2:
+            with pytest.raises(SystemError):
+                utils.create_lookup_table(outfile_name, method="Zhang2018", 
+                                          cosmo=cosmo, free_elec=-1)
+
 
 
 class TestPlots:

--- a/fruitbat/utils.py
+++ b/fruitbat/utils.py
@@ -3,6 +3,7 @@ Utility functions for Fruitbat
 """
 from __future__ import print_function, absolute_import, division
 import os
+from six import PY3, PY2
 
 import numpy as np
 import scipy.integrate as integrate
@@ -84,21 +85,33 @@ def create_lookup_table(filename, method, cosmo, zmin=0, zmax=20,
     ---------
     filename.npy:
 
+    Warning
+    -------
+    Generating lookup tables is only avaliable when using **fruitbat** in
+    Python 3.
+
     """
+    if PY3:
+        dm_method_dict = {
+            "Ioka2003": _calc_dm_ioka2003,
+            "Inoue2004": _calc_dm_inoue2004,
+            "Zhang2018": _calc_dm_zhang2018
+        }
 
-    dm_method_dict = {
-        "Ioka2003": _calc_dm_ioka2003,
-        "Inoue2004": _calc_dm_inoue2004,
-        "Zhang2018": _calc_dm_zhang2018
-    }
+        interp = _perform_interpolation(dm_func=dm_method_dict[method],
+                                        cosmo=cosmo,
+                                        zmin=zmin, zmax=zmax,
+                                        num_samples=num_samples,
+                                        **kwargs)
 
-    interp = _perform_interpolation(dm_func=dm_method_dict[method],
-                                    cosmo=cosmo,
-                                    zmin=zmin, zmax=zmax,
-                                    num_samples=num_samples,
-                                    **kwargs)
+        _save_lookup_table(filename, interp)
 
-    _save_lookup_table(interp, filename)
+    elif PY2:
+        raise SystemError("""create_lookup_table is a python 3 only feature. 
+                          A lookup table is in reality a pickled instance 
+                          method of the scipy.interpolate.interp1D. Since
+                          pickling an instance method in Python 2 is not 
+                          supported, this is restricted to Python 3 only.""")
 
 
 def _fz_integrand(z, cosmo):
@@ -275,9 +288,10 @@ def _check_keys_in_dict(dictionary, keys):
     return True
 
 
-def _save_lookup_table(table, filename):
+def _save_lookup_table(filename, table):
     """
     Saves the lookup table to a .npy file
     """
+    
     np.save(filename, table)
     return None

--- a/fruitbat/utils.py
+++ b/fruitbat/utils.py
@@ -1,7 +1,7 @@
 """
 Utility functions for Fruitbat
 """
-
+from __future__ import print_function, absolute_import, division
 import os
 
 import numpy as np

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy>=1.12.0
 scipy>=1.0.0
 astropy>=2.0.0
-matplotlib>=2.2
+matplotlib>=2.2.4
+six>=1.11.0
 pyymw16>=2.0.4
 e13tools>=0.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,6 @@
+-e .
+check-manifest
+pytest>=3.8.0
+pytest-mpl
+pytest-cov
+codecov

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt", "r") as f:
 
 setup(
     name='fruitbat',
-    version='0.1.1',
+    version='0.2.0',
     author='Adam Batten',
     author_email='adamjbatten@gmail.com',
     url='https://github.com/abatten/fruitbat',
@@ -23,6 +23,8 @@ setup(
     long_description=long_description,
     install_requires=requirements,
     classifiers=[
+        "Programming Language :: Python :: 2"
+        "Programming Language :: Python :: 2.7"
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
* Added compatibility to python 2.7 (which was a big update)
    - Removed support for create_lookup_tabe for python 2.7
    - cosmology_plot skips inset plot
    - Added imports from __future__
    - Moved *args to **kwargs to the end of Frb
* Added requirement_dev for all requirements needed for testing.
* Added six as a requirement to check PY2 vs PY3
* Deleted _fruitbatstrings.py file
